### PR TITLE
feat: Add Docker Hub deployment setup for Basic Authentication example

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,69 @@
+# Git
+.git
+.gitignore
+.gitattributes
+
+# Documentation
+README.md
+docs/
+*.md
+
+# IDE files
+.vscode/
+.idea/
+*.iml
+*.ipr
+*.iws
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Node.js
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Build artifacts
+target/
+dist/
+build/
+*.war
+*.jar
+
+# Logs
+logs/
+*.log
+
+# Temporary files
+tmp/
+temp/
+*.tmp
+*.temp
+
+# Coverage reports
+coverage/
+.nyc_output/
+
+# Environment files
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Docker files
+Dockerfile*
+docker-compose*.yml
+.dockerignore
+
+# GitHub
+.github/
+
+# Other examples (only include basicauthentication)
+examples/azureblobviewer/
+examples/README.md
+
+# Core module (not needed for basic auth example)
+core/

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,47 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+      
+    - name: Log in to Docker Hub
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+        
+    - name: Extract metadata
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: surendocker/jaqstack-examples
+        tags: |
+          type=ref,event=branch
+          type=ref,event=pr
+          type=sha,prefix={{branch}}-
+          type=raw,value=latest,enable={{is_default_branch}}
+          
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        platforms: linux/amd64,linux/arm64
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/DOCKER_SETUP.md
+++ b/DOCKER_SETUP.md
@@ -1,0 +1,153 @@
+# Docker Hub Deployment Setup
+
+This guide explains how to set up automatic Docker Hub deployment for the JAQ Stack Examples repository.
+
+## Overview
+
+The repository is configured with:
+- **Dockerfile**: Builds the Basic Authentication example
+- **GitHub Actions**: Automatically builds and pushes to Docker Hub on main branch pushes
+- **Docker Hub Repository**: `surendocker/jaqstack-examples`
+
+## Prerequisites
+
+1. Docker Hub account
+2. GitHub repository with Actions enabled
+3. Docker installed locally (for testing)
+
+## Setup Instructions
+
+### 1. Create Docker Hub Repository
+
+1. Go to [Docker Hub](https://hub.docker.com/)
+2. Click "Create Repository"
+3. Set repository name: `jaqstack-examples`
+4. Set visibility: Public or Private (your choice)
+5. Click "Create"
+
+### 2. Set up GitHub Secrets
+
+1. Go to your GitHub repository
+2. Navigate to **Settings** → **Secrets and variables** → **Actions**
+3. Click **New repository secret**
+4. Add the following secrets:
+
+#### DOCKERHUB_USERNAME
+- **Name**: `DOCKERHUB_USERNAME`
+- **Value**: Your Docker Hub username (e.g., `surendocker`)
+
+#### DOCKERHUB_TOKEN
+- **Name**: `DOCKERHUB_TOKEN`
+- **Value**: Your Docker Hub access token
+
+**To create a Docker Hub access token:**
+1. Go to Docker Hub → Account Settings → Security
+2. Click "New Access Token"
+3. Give it a name (e.g., "GitHub Actions")
+4. Set permissions to "Read, Write, Delete"
+5. Copy the generated token
+
+### 3. Test the Setup
+
+1. Push changes to the `main` branch
+2. Go to **Actions** tab in your GitHub repository
+3. Watch the "Build and Push Docker Image" workflow
+4. Check Docker Hub for the new image
+
+## Using the Deployed Image
+
+### Pull and Run the Image
+
+```bash
+# Pull the latest image
+docker pull surendocker/jaqstack-examples:latest
+
+# Run the container
+docker run -d -p 8080:8080 --name jaqstack-app surendocker/jaqstack-examples:latest
+```
+
+### Access the Application
+
+- **URL**: http://localhost:8080
+- **Basic Authentication Example**: http://localhost:8080
+
+### Environment Variables
+
+You can customize the application with environment variables:
+
+```bash
+docker run -d -p 8080:8080 \
+  -e JAVA_OPTS="-Xmx1024m -Xms512m" \
+  --name jaqstack-app \
+  surendocker/jaqstack-examples:latest
+```
+
+### Docker Compose (Optional)
+
+Create a `docker-compose.yml` file:
+
+```yaml
+version: '3.8'
+services:
+  jaqstack-app:
+    image: surendocker/jaqstack-examples:latest
+    ports:
+      - "8080:8080"
+    environment:
+      - JAVA_OPTS=-Xmx1024m -Xms512m
+    restart: unless-stopped
+```
+
+Then run:
+```bash
+docker-compose up -d
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Build fails**: Check that all secrets are set correctly
+2. **Push fails**: Verify Docker Hub token has correct permissions
+3. **Image not found**: Ensure the repository name matches exactly
+
+### Checking Logs
+
+```bash
+# Check container logs
+docker logs jaqstack-app
+
+# Check GitHub Actions logs
+# Go to Actions tab → Click on failed workflow → View logs
+```
+
+### Manual Build (for testing)
+
+```bash
+# Build locally
+docker build -t jaqstack-examples:local .
+
+# Run locally
+docker run -d -p 8080:8080 --name jaqstack-app jaqstack-examples:local
+```
+
+## Image Tags
+
+The workflow creates multiple tags:
+- `latest`: Latest version from main branch
+- `main`: Branch-specific tag
+- `sha-<commit-hash>`: Specific commit tags
+
+## Security Notes
+
+- Never commit Docker Hub credentials to the repository
+- Use GitHub Secrets for all sensitive information
+- Regularly rotate your Docker Hub access tokens
+- Consider using Docker Hub's automated security scanning
+
+## Support
+
+For issues with:
+- **Docker**: Check [Docker documentation](https://docs.docker.com/)
+- **GitHub Actions**: Check [GitHub Actions documentation](https://docs.github.com/en/actions)
+- **Docker Hub**: Check [Docker Hub documentation](https://docs.docker.com/docker-hub/)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# Use OpenJDK 11 as base image
+FROM openjdk:11-jre-slim
+
+# Set working directory
+WORKDIR /app
+
+# Install Maven
+RUN apt-get update && \
+    apt-get install -y maven && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy Maven files first for better caching
+COPY examples/basicauthentication/pom.xml /app/pom.xml
+
+# Copy source code
+COPY examples/basicauthentication/src /app/src
+
+# Copy UI resources
+COPY examples/basicauthentication/ui.resources /app/ui.resources
+
+# Build the application
+RUN mvn clean package -DskipTests
+
+# Expose port 8080
+EXPOSE 8080
+
+# Set environment variables
+ENV JAVA_OPTS="-Xmx512m -Xms256m"
+
+# Run the application
+CMD ["java", "-jar", "target/jaq-stack-webapp.war"]


### PR DESCRIPTION
Docker Configuration:
- Add Dockerfile for Basic Authentication example
- Use OpenJDK 11 base image with Maven
- Expose port 8080 for web application
- Simple build process without complex dependencies

GitHub Actions:
- Create automated Docker Hub deployment workflow
- Trigger on pushes to main branch
- Support multi-platform builds (AMD64/ARM64)
- Use Docker Hub secrets for secure authentication
- Create multiple tags (latest, branch, commit)

Optimization:
- Add .dockerignore to exclude unnecessary files
- Focus on Basic Authentication example only
- Exclude other examples and build artifacts

Documentation:
- Add comprehensive DOCKER_SETUP.md guide
- Include GitHub Secrets setup instructions
- Provide Docker Hub repository creation steps
- Add troubleshooting and usage examples
- Include security best practices

This setup enables automatic deployment of the JAQ Stack Basic Authentication example to Docker Hub with minimal configuration and maximum security.