### PR TITLE
fix: Install Angular CLI globally in Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && \
     apt-get install -y maven curl && \
     curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
     apt-get install -y nodejs && \
-    npm install -g yarn && \
+    npm install -g yarn @angular/cli && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
- Add @angular/cli to global npm installation
- Fix 'ng command not found' error during Docker build
- Ensure Angular CLI is available for frontend build process
- Maintain simple Dockerfile structure