### PR TITLE
fix: Use JDK instead of JRE for Java compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Use OpenJDK 11 as base image
-FROM openjdk:11-jre-slim
+# Use OpenJDK 11 JDK as base image (needed for compilation)
+FROM openjdk:11-jdk-slim
 
 # Set working directory
 WORKDIR /app


### PR DESCRIPTION
- Change base image from openjdk:11-jre-slim to openjdk:11-jdk-slim
- Fix 'No compiler is provided' error during Maven build
- JDK includes Java compiler needed for Maven compilation
- JRE only includes runtime, not development tools