### PR TITLE
fix: Use Node.js base image with Java added for more reliable build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,17 @@
-# Use OpenJDK 11 JDK as base image (needed for compilation)
-FROM openjdk:11-jdk-slim
+# Use Node.js 18 as base image, then add Java
+FROM node:18-slim
 
 # Set working directory
 WORKDIR /app
 
-# Install Maven, Node.js, and Yarn
+# Install Java 11 JDK and Maven
 RUN apt-get update && \
-    apt-get install -y maven curl && \
-    curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
-    apt-get install -y nodejs && \
-    npm install -g yarn @angular/cli && \
+    apt-get install -y openjdk-11-jdk maven && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+# Install Yarn and Angular CLI globally
+RUN npm install -g yarn @angular/cli
 
 # Copy Maven files first for better caching
 COPY examples/basicauthentication/pom.xml /app/pom.xml


### PR DESCRIPTION
- Change from openjdk:11-jdk-slim to node:18-slim base
- Install Java 11 JDK and Maven on Node.js base
- Avoid NodeSource repository setup issues
- More reliable package installation approach
- Node.js, Yarn, and Angular CLI come pre-installed