### PR TITLE
fix: Use --unsafe-perm flag for npm global installations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install Yarn and Angular CLI globally
-RUN npm install -g yarn @angular/cli
+RUN npm install -g --unsafe-perm yarn@latest && \
+    npm install -g --unsafe-perm @angular/cli@latest
 
 # Copy Maven files first for better caching
 COPY examples/basicauthentication/pom.xml /app/pom.xml


### PR DESCRIPTION
- Add --unsafe-perm flag to npm install commands
- Install yarn and @angular/cli separately for better reliability
- Fix npm install permission issues in Docker container
- Use latest versions explicitly for consistency