### PR TITLE
fix: Remove yarn installation as it's already available in Node.js image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,8 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Install Yarn and Angular CLI globally
-RUN npm install -g --unsafe-perm yarn@latest && \
-    npm install -g --unsafe-perm @angular/cli@latest
+# Install Angular CLI globally (Yarn is already available in Node.js image)
+RUN npm install -g --unsafe-perm @angular/cli@latest
 
 # Copy Maven files first for better caching
 COPY examples/basicauthentication/pom.xml /app/pom.xml


### PR DESCRIPTION
- Remove yarn installation since it's pre-installed in node:18-slim
- Only install Angular CLI which is not available by default
- Fix EEXIST error caused by trying to install existing yarn
- Simplify Dockerfile by using pre-installed tools