### PR TITLE
fix: Add modern maven-war-plugin to resolve compatibility issues

### DIFF
--- a/examples/basicauthentication/pom.xml
+++ b/examples/basicauthentication/pom.xml
@@ -17,6 +17,7 @@
     <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
     <maven-clean-plugin.version>3.3.2</maven-clean-plugin.version>
     <maven-surefire-plugin.version>3.2.2</maven-surefire-plugin.version>
+    <maven-war-plugin.version>3.4.0</maven-war-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>17</java.version>
@@ -247,6 +248,15 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <version>${maven-war-plugin.version}</version>
+        <configuration>
+          <warName>${project.artifactId}</warName>
+          <failOnMissingWebXml>false</failOnMissingWebXml>
+        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
- Add maven-war-plugin.version=3.4.0 property
- Configure maven-war-plugin with modern version
- Set warName to project.artifactId (basicauth)
- Set failOnMissingWebXml=false for flexibility
- Resolves API incompatibility with old plugin version 2.2
- Compatible with Java 17 and modern Maven