### PR TITLE
fix: Improve network reliability for Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -24,6 +24,8 @@ node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+package-lock.json
+yarn.lock
 
 # Build artifacts
 target/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Use Node.js 18 as base image, then add Java
+        # Use Node.js 18 as base image, then add Java
 FROM node:18-slim
 
 # Set working directory
@@ -25,7 +25,13 @@ COPY examples/basicauthentication/ui.resources /app/ui.resources
 
 # Build the Angular frontend first
 WORKDIR /app/ui.resources
-RUN yarn install && yarn build
+# Use npm instead of yarn for better Docker reliability
+# Add network timeout and retry configurations
+RUN npm config set fetch-retry-mintimeout 20000 && \
+    npm config set fetch-retry-maxtimeout 120000 && \
+    npm config set fetch-retries 5 && \
+    npm install && \
+    npm run build
 
 # Go back to app directory and build the Java application
 WORKDIR /app

--- a/examples/basicauthentication/pom.xml
+++ b/examples/basicauthentication/pom.xml
@@ -193,10 +193,10 @@
         </configuration>
         <executions>
           <execution>
-            <id>exec-yarn-install</id>
+            <id>exec-npm-install</id>
             <phase>generate-sources</phase>
             <configuration>
-              <executable>yarn</executable>
+              <executable>npm</executable>
               <arguments>
                 <argument>install</argument>
               </arguments>
@@ -209,8 +209,9 @@
             <id>exec-ngcli-build</id>
             <phase>generate-sources</phase>
             <configuration>
-              <executable>ng</executable>
+              <executable>npx</executable>
               <arguments>
+                <argument>ng</argument>
                 <argument>build</argument>
                 <argument>--base-href=#context-path#</argument>
               </arguments>


### PR DESCRIPTION
- Switch from yarn to npm for better Docker reliability
- Add npm network timeout and retry configurations
- Set fetch-retry-mintimeout: 20000ms
- Set fetch-retry-maxtimeout: 120000ms
- Set fetch-retries: 5 attempts
- Update Maven exec plugin to use npm instead of yarn
- Use npx for Angular CLI execution
- Add package-lock.json and yarn.lock to .dockerignore
- Resolves ESOCKETTIMEDOUT network issues during build