### PR TITLE
fix: Use correct Docker base image for Java 17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use a pre-built Java application approach
-FROM openjdk:17-jre-slim
+FROM eclipse-temurin:17-jre
 
 # Set working directory
 WORKDIR /app


### PR DESCRIPTION
- Change from openjdk:17-jre-slim (doesn't exist) to eclipse-temurin:17-jre
- Eclipse Temurin is the official OpenJDK distribution
- More reliable and actively maintained
- Supports both linux/amd64 and linux/arm64 platforms