### PR TITLE
fix: Add --legacy-peer-deps to Maven npm install

### DIFF
--- a/examples/basicauthentication/pom.xml
+++ b/examples/basicauthentication/pom.xml
@@ -199,6 +199,7 @@
               <executable>npm</executable>
               <arguments>
                 <argument>install</argument>
+                <argument>--legacy-peer-deps</argument>
               </arguments>
             </configuration>
             <goals>


### PR DESCRIPTION
- Add --legacy-peer-deps flag to Maven exec plugin npm install
- Resolves ERESOLVE TypeScript dependency conflicts in Docker build
- Allows npm to use legacy dependency resolution algorithm
- Fixes conflicting peer dependencies between Angular 17 packages
- Ensures Maven build completes successfully in Docker