### PR TITLE
fix: Add missing tslib dependency for TypeScript decorators

### DIFF
--- a/examples/basicauthentication/ui.resources/package.json
+++ b/examples/basicauthentication/ui.resources/package.json
@@ -24,6 +24,7 @@
     "@angular/platform-browser-dynamic": "^17.0.0",
     "@angular/router": "^17.0.0",
     "rxjs": "^7.8.0",
+    "tslib": "^2.6.0",
     "zone.js": "^0.14.0"
   },
   "devDependencies": {


### PR DESCRIPTION
- Add tslib@^2.6.0 to dependencies in package.json
- tslib is required for TypeScript decorators like @Component
- Resolves 'module tslib cannot be found' error
- Critical runtime library for Angular decorators
- Fixes TypeScript compilation in Docker build