### PR TITLE
fix: Use JDK instead of JRE for Java compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build only the basicauthentication example
-FROM eclipse-temurin:17-jre
+FROM eclipse-temurin:17-jdk
 
 # Set working directory
 WORKDIR /app


### PR DESCRIPTION
- Change from eclipse-temurin:17-jre to eclipse-temurin:17-jdk
- JRE only has runtime, JDK has compiler (javac) needed for Maven
- Resolves 'No compiler is provided in this environment' error
- Angular build now works, Java compilation was the remaining issue
- Complete build should now succeed