### PR TITLE
fix: Remove old lock files to prevent npm build hanging

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -26,6 +26,8 @@ yarn-debug.log*
 yarn-error.log*
 package-lock.json
 yarn.lock
+**/package-lock.json
+**/yarn.lock
 
 # Build artifacts
 target/

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,9 @@ COPY examples/basicauthentication/pom.xml /app/pom.xml
 COPY examples/basicauthentication/src /app/src
 COPY examples/basicauthentication/ui.resources /app/ui.resources
 
+# Remove old lock files to avoid npm warnings
+RUN rm -f /app/ui.resources/package-lock.json /app/ui.resources/yarn.lock
+
 # Build the Java application (skip frontend build for now)
 RUN mvn clean package -DskipTests
 


### PR DESCRIPTION
- Add explicit removal of package-lock.json and yarn.lock in Dockerfile
- Update .dockerignore to exclude lock files from build context
- Prevents 'old lockfile' warnings that cause npm to hang
- Forces npm to create fresh lock file with current version
- Resolves build hanging during dependency resolution